### PR TITLE
Fix empty instance bug

### DIFF
--- a/magpie/bin/protocol.py
+++ b/magpie/bin/protocol.py
@@ -33,7 +33,9 @@ class BasicProtocol:
 
         bins = [[]]
         for s in sec['batch_instances'].splitlines():
-            if s == '___':
+            if s == '':
+                continue
+            elif s == '___':
                 if not bins[-1]:
                     raise ValueError('Invalid config file: empty bin in "{}"'.format(sec['search']['batch_all_samples']))
                 bins.append([])


### PR DESCRIPTION
This PR fixes the bug where an empty string is stored as one of the batch instances, causing a CODE_ERROR when that instance is run. This is because `sec['batch_instances']` has the form `"\n..."`, so the first element of `sec['batch_instances'].splitlines()` will always be `''`.